### PR TITLE
Change attribute value types

### DIFF
--- a/python_boleto/base.py
+++ b/python_boleto/base.py
@@ -19,6 +19,7 @@ import six
 from python_boleto import STATIC_DIR
 
 from . import filters
+from iso8601 import iso8601
 
 if six.PY2:
     from urlparse import urljoin
@@ -75,6 +76,27 @@ class Boleto(object):
             # as propriedades banco e template não podem ser alteradas no init
             if not k in ('banco', 'template') and hasattr(self, k):
                 setattr(self, k, v)
+
+    def __setattr__(self, name, value):
+        '''
+        Transforma os valores de acordo com os tipos
+        '''
+        if name in ('valor_unitario', 'valor_documento', 'valor_desconto',
+                    'valor_outras_deducoes', 'valor_multa', 'valor_outros_acrescimos',
+                    'valor_cobrado'):
+            value = Decimal(value)
+
+        elif name in ('vencimento', 'data_documento', 'data_processamento'):
+            if isinstance(value, six.string_types):
+                value = iso8601.parse_date(value).date()
+
+        elif name in ('quantidade', 'num_sequencial'):
+            try:
+                value = int(value)
+            except:
+                value = 0
+
+        return super(Boleto, self).__setattr__(name, value)
 
     @property
     def nosso_numero(self):

--- a/python_boleto_tests/test_base.py
+++ b/python_boleto_tests/test_base.py
@@ -37,9 +37,7 @@ def test_base_validate():
 
     # num_sequencial
     base.num_sequencial = ''
-    with pytest.raises(TypeError) as excinfo:
-        base.validate()
-    assert "num_sequencial" in str(excinfo)
+    assert base.num_sequencial == 0
 
     base.num_sequencial = -1
     with pytest.raises(ValueError) as excinfo:
@@ -49,9 +47,7 @@ def test_base_validate():
 
     # quantidade
     base.quantidade = ''
-    with pytest.raises(TypeError) as excinfo:
-        base.validate()
-    assert "quantidade" in str(excinfo)
+    assert base.quantidade == 0
 
     base.quantidade = -1
     with pytest.raises(ValueError) as excinfo:
@@ -82,51 +78,37 @@ def test_base_validate():
 
     # valor_unitario
     base.valor_unitario = -1
-    with pytest.raises(TypeError) as excinfo:
-        base.validate()
-    assert "valor_unitario" in str(excinfo)
+    assert base.valor_unitario == Decimal(-1)
     base.valor_unitario = Decimal()
 
     # valor_documento
     base.valor_documento = -1
-    with pytest.raises(TypeError) as excinfo:
-        base.validate()
-    assert "valor_documento" in str(excinfo)
+    assert base.valor_documento == Decimal(-1)
     base.valor_documento = Decimal()
 
     # valor_desconto
     base.valor_desconto = -1
-    with pytest.raises(TypeError) as excinfo:
-        base.validate()
-    assert "valor_desconto" in str(excinfo)
+    assert base.valor_desconto == Decimal(-1)
     base.valor_desconto = Decimal()
 
     # valor_outras_deducoes
     base.valor_outras_deducoes = -1
-    with pytest.raises(TypeError) as excinfo:
-        base.validate()
-    assert "valor_outras_deducoes" in str(excinfo)
+    assert base.valor_outras_deducoes == Decimal(-1)
     base.valor_outras_deducoes = Decimal()
 
     # valor_multa
     base.valor_multa = -1
-    with pytest.raises(TypeError) as excinfo:
-        base.validate()
-    assert "valor_multa" in str(excinfo)
+    assert base.valor_multa == Decimal(-1)
     base.valor_multa = Decimal()
 
     # valor_outros_acrescimos
     base.valor_outros_acrescimos = -1
-    with pytest.raises(TypeError) as excinfo:
-        base.validate()
-    assert "valor_outros_acrescimos" in str(excinfo)
+    assert base.valor_outros_acrescimos == Decimal(-1)
     base.valor_outros_acrescimos = Decimal()
 
     # valor_cobrado
     base.valor_cobrado = -1
-    with pytest.raises(TypeError) as excinfo:
-        base.validate()
-    assert "valor_cobrado" in str(excinfo)
+    assert base.valor_cobrado == Decimal(-1)
     base.valor_cobrado = Decimal()
 
     # numero_documento

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ TESTS_REQUIRES = [
     'pytest>=2.8.4',
     'pytest-cov>=2.2.0',
     'flake8>=2.4,<3',
-    'pep8-naming>=0.2,<1'
+    'pep8-naming>=0.2,<1',
+    'iso8601'
 ]
 
 EXTRAS_REQUIRES = {


### PR DESCRIPTION
When setting Boleto class instance, they are passed through the base type class constructor to ensure they are valid and can be parsed and serialized from a dict.
